### PR TITLE
Specify ssh-rsa as allowed key method

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -170,6 +170,8 @@ int create_ssh_session(ssh_session *session, const char *address,
   /* SSH Connection Config */
   ssh_options_set(*session, SSH_OPTIONS_HOST, address);
   ssh_options_set(*session, SSH_OPTIONS_PORT, &port);
+  ssh_options_set(*session, SSH_OPTIONS_HOSTKEYS, "+ssh-rsa");
+  ssh_options_set(*session, SSH_OPTIONS_PUBLICKEY_ACCEPTED_TYPES, "+ssh-rsa");
 
   /* Try to establish connection */
   if (ssh_connect(*session) != SSH_OK) {


### PR DESCRIPTION
OpenSSH 8.8 [has stopped allowing](https://remarkable.guide/faqs.html#how-do-i-resolve-the-no-matching-host-key-type-found-their-offer-ssh-rsa-error-when-attempting-to-ssh-into-my-device) ssh-rsa by default, which the remarkable uses. On newer operating systems, we have to tell SSH that's OK.